### PR TITLE
Align OR gate models to reference style

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
@@ -1,12 +1,11 @@
-
 // Copyright 2024 IHP PDK Authors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //    https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,57 +14,1008 @@
 
 `include "disciplines.vams"
 
-module sg13g2_nand2_1(Y, A, B);
+// Analog behavior parameters are declared per cell to mirror digital functionality
 
-input A, B; 
-output Y; 
-electrical Y;
-electrical A, B;
-parameter real vh = 1.2;			// output electrical in high state
-parameter real vl = 0;			    // output electrical in low state
-parameter real vth = (vh + vl)/2;	// threshold electrical at inputs
-parameter real td = 0 from [0:inf);	// delay to start of output transition
-parameter real tt = 0 from [0:inf);	// transition time of output signals
-
+// Basic combinational helpers
+module sg13g2_buf_base #(parameter real vh = 1.2, parameter real vl = 0, parameter real vth = (vh + vl)/2, parameter real td = 0 from [0:inf), parameter real tt = 0 from [0:inf)) (output electrical X, input electrical A);
 analog begin
-    @(cross(V(A) - vth) or cross(V(B) - vth));
-
-    V(Y) <+ transition( !((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt );
+    @(cross(V(A) - vth)) V(X) <+ transition((V(A) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-
-module sg13g2_dfrbpq_1 (Q, D, RESET_B, CLK);
-
-output Q; 
-electrical Q;	// Q output
-input D; 
-electrical D;	// D input
-input RESET_B; 
-electrical RESET_B;	// Clock input (edge triggered)
-input CLK; 
-electrical CLK;	// D input
-parameter real td = 0 from [0:inf);	// delay from clock to q
-parameter real tt = 0 from [0:inf);	// transition time of output signals
-parameter real vh = 1.2;			// output voltage in high state
-parameter real vl = 0;			// output voltage in low state
-parameter real vth = (vh + vl)/2;	// threshold voltage at inputs
-parameter integer dir = +1 from [-1:+1] exclude 0;
-			// if dir=+1, rising clock edge triggers flip flop 
-			// if dir=-1, falling clock edge triggers flip flop 
-real state;
-
+module sg13g2_inv_base #(parameter real vh = 1.2, parameter real vl = 0, parameter real vth = (vh + vl)/2, parameter real td = 0 from [0:inf), parameter real tt = 0 from [0:inf)) (output electrical Y, input electrical A);
 analog begin
-    @(cross(V(CLK) - vth, dir))
-	state = (V(D) > vth);
-    if (V(RESET_B) < vth) 
-        state = 0;
-    V(Q) <+ transition( state ? vh : vl, td, tt );
+    @(cross(V(A) - vth)) V(Y) <+ transition(!(V(A) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
+// Combinational cells
+module sg13g2_a21o_1 (output electrical X, input electrical A1, A2, B1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
+        V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
+end
+endmodule
 
+module sg13g2_a21o_2 (output electrical X, input electrical A1, A2, B1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
+        V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
+end
+endmodule
 
+module sg13g2_a21oi_1 (output electrical Y, input electrical A1, A2, B1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
+        V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
+end
+endmodule
 
+module sg13g2_a21oi_2 (output electrical Y, input electrical A1, A2, B1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
+        V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
+end
+endmodule
 
+module sg13g2_a221oi_1 (output electrical Y, input electrical A1, A2, B1, B2, C1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth) or cross(V(C1)-vth))
+        V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth)) || (V(C1) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_a22oi_1 (output electrical Y, input electrical A1, A2, B1, B2);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth))
+        V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth))) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and2_1 (output electrical X, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and2_2 (output electrical X, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and3_1 (output electrical X, input electrical A, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and3_2 (output electrical X, input electrical A, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and4_1 (output electrical X, input electrical A, B, C, D);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_and4_2 (output electrical X, input electrical A, B, C, D);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
+        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
+end
+endmodule
+
+// Antenna/filler/decap cells do not drive signals
+module sg13g2_antennanp (input electrical A);
+endmodule
+module sg13g2_fill_1(); endmodule
+module sg13g2_fill_2(); endmodule
+module sg13g2_fill_4(); endmodule
+module sg13g2_fill_8(); endmodule
+module sg13g2_decap_4(); endmodule
+module sg13g2_decap_8(); endmodule
+
+// Buffers and inverters
+module sg13g2_buf_1 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_buf_2 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_buf_4 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_buf_8 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_buf_16 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+
+module sg13g2_inv_1 (output electrical Y, input electrical A);
+    sg13g2_inv_base inv_i(.Y(Y), .A(A));
+endmodule
+module sg13g2_inv_2 (output electrical Y, input electrical A);
+    sg13g2_inv_base inv_i(.Y(Y), .A(A));
+endmodule
+module sg13g2_inv_4 (output electrical Y, input electrical A);
+    sg13g2_inv_base inv_i(.Y(Y), .A(A));
+endmodule
+module sg13g2_inv_8 (output electrical Y, input electrical A);
+    sg13g2_inv_base inv_i(.Y(Y), .A(A));
+endmodule
+module sg13g2_inv_16 (output electrical Y, input electrical A);
+    sg13g2_inv_base inv_i(.Y(Y), .A(A));
+endmodule
+
+// Multiplexers
+module sg13g2_mux2_1 (output electrical X, input electrical A0, A1, S);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth))
+        V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
+end
+endmodule
+
+module sg13g2_mux2_2 (output electrical X, input electrical A0, A1, S);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth))
+        V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
+end
+endmodule
+
+module sg13g2_mux4_1 (output electrical X, input electrical A0, A1, A2, A3, S0, S1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(A3)-vth) or cross(V(S0)-vth) or cross(V(S1)-vth)) begin
+        integer sel0, sel1;
+        sel0 = (V(S0) > vth);
+        sel1 = (V(S1) > vth);
+        if (!sel1 && !sel0)
+            V(X) <+ transition((V(A0) > vth)?vh:vl, td, tt);
+        else if (!sel1 && sel0)
+            V(X) <+ transition((V(A1) > vth)?vh:vl, td, tt);
+        else if (sel1 && !sel0)
+            V(X) <+ transition((V(A2) > vth)?vh:vl, td, tt);
+        else
+            V(X) <+ transition((V(A3) > vth)?vh:vl, td, tt);
+    end
+end
+endmodule
+
+// NAND / NOR variations
+module sg13g2_nand2_1 (output electrical Y, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand2_2 (output electrical Y, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand2b_1 (output electrical Y, input electrical A_N, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A_N)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand2b_2 (output electrical Y, input electrical A_N, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A_N)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand3_1 (output electrical Y, input electrical A, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand3b_1 (output electrical Y, input electrical A_N, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A_N)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(Y) <+ transition(!((!(V(A_N) > vth))&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nand4_1 (output electrical Y, input electrical A, B, C, D);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
+        V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)&&(V(D) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor2_1 (output electrical Y, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor2_2 (output electrical Y, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor2b_1 (output electrical Y, input electrical A, B_N);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B_N)-vth))
+        V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor2b_2 (output electrical Y, input electrical A, B_N);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B_N)-vth))
+        V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor3_1 (output electrical Y, input electrical A, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor3_2 (output electrical Y, input electrical A, B, C);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
+        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor4_1 (output electrical Y, input electrical A, B, C, D);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
+        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_nor4_2 (output electrical Y, input electrical A, B, C, D);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
+        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_o21ai_1 (output electrical Y, input electrical A1, A2, B1);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
+        V(Y) <+ transition(!(((V(A1) > vth)||(V(A2) > vth)) && (V(B1) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or2_1 (X, A, B);
+    output X;
+    electrical X;
+    input A, B;
+    electrical A, B;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or2_2 (X, A, B);
+    output X;
+    electrical X;
+    input A, B;
+    electrical A, B;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or3_1 (X, A, B, C);
+    output X;
+    electrical X;
+    input A, B, C;
+    electrical A, B, C;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or3_2 (X, A, B, C);
+    output X;
+    electrical X;
+    input A, B, C;
+    electrical A, B, C;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or4_1 (X, A, B, C, D);
+    output X;
+    electrical X;
+    input A, B, C, D;
+    electrical A, B, C, D;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth) || (V(D) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_or4_2 (X, A, B, C, D);
+    output X;
+    electrical X;
+    input A, B, C, D;
+    electrical A, B, C, D;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth) || (V(D) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+// Exclusive gates
+module sg13g2_xor2_1 (output electrical X, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(X) <+ transition(((V(A) > vth) ^ (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_xnor2_1 (output electrical Y, input electrical A, B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    @(cross(V(A)-vth) or cross(V(B)-vth))
+        V(Y) <+ transition(((V(A) > vth) ~^ (V(B) > vth)) ? vh : vl, td, tt);
+end
+endmodule
+
+// Tri-state and enable inverters
+module sg13g2_ebufn_2 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = (V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+module sg13g2_ebufn_4 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = (V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+module sg13g2_ebufn_8 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = (V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_einvn_2 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = !(V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+module sg13g2_einvn_4 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = !(V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+module sg13g2_einvn_8 (inout electrical Z, input electrical A, TE_B);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+        if (!(V(TE_B) > vth))
+            state = !(V(A) > vth);
+    end
+    V(Z) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// Tie cells
+module sg13g2_tiehi (output electrical L_HI);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    V(L_HI) <+ transition(vh, td, tt);
+end
+endmodule
+
+module sg13g2_tielo (output electrical L_LO);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+analog begin
+    V(L_LO) <+ transition(vl, td, tt);
+end
+endmodule
+
+// Clock gating helpers
+module sg13g2_lgcp_1 (output electrical GCLK, input electrical GATE, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(GATE)-vth) or cross(V(CLK)-vth)) begin
+        state = (V(GATE) > vth) && (V(CLK) > vth);
+    end
+    V(GCLK) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_slgcp_1 (output electrical GCLK, input electrical GATE, SCE, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(GATE)-vth) or cross(V(SCE)-vth) or cross(V(CLK)-vth)) begin
+        state = (((V(GATE) > vth) && !(V(SCE) > vth)) || (V(SCE) > vth)) && (V(CLK) > vth);
+    end
+    V(GCLK) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// Latches
+module sg13g2_dlhq_1 (output electrical Q, input electrical D, GATE);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(GATE)-vth)) begin
+        if ((V(GATE) > vth))
+            state = (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dlhr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GATE);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if ((V(GATE) > vth))
+            state = (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dlhrq_1 (output electrical Q, input electrical D, RESET_B, GATE);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if ((V(GATE) > vth))
+            state = (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dllr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GATE_N);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (!(V(GATE_N) > vth))
+            state = (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dllrq_1 (output electrical Q, input electrical D, RESET_B, GATE_N);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (!(V(GATE_N) > vth))
+            state = (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// D flip-flops
+module sg13g2_dfrbp_1 (output electrical Q, Q_N, input electrical D, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dfrbp_2 (output electrical Q, Q_N, input electrical D, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dfrbpq_1 (output electrical Q, input electrical D, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_dfrbpq_2 (output electrical Q, input electrical D, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// Scan DFF with reset and optional set
+module sg13g2_sdfbbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, SET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(SET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (!(V(SET_B) > vth))
+            state = 1;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(SCE) > vth) ? (V(SCD) > vth) : (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_sdfrbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(SCE) > vth) ? (V(SCD) > vth) : (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_sdfrbp_2 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(SCE) > vth) ? (V(SCD) > vth) : (V(D) > vth);
+    end
+    V(Q)   <+ transition(state ? vh : vl, td, tt);
+    V(Q_N) <+ transition(!state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_sdfrbpq_1 (output electrical Q, input electrical D, SCD, SCE, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(SCE) > vth) ? (V(SCD) > vth) : (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+module sg13g2_sdfrbpq_2 (output electrical Q, input electrical D, SCD, SCE, RESET_B, CLK);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+        if (!(V(RESET_B) > vth))
+            state = 0;
+        else if (cross(V(CLK)-vth, +1))
+            state = (V(SCE) > vth) ? (V(SCD) > vth) : (V(D) > vth);
+    end
+    V(Q) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// Bus hold cell
+module sg13g2_sighold (inout electrical SH);
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
+    real state;
+analog begin
+    @(cross(V(SH)-vth)) state = (V(SH) > vth);
+    V(SH) <+ transition(state ? vh : vl, td, tt);
+end
+endmodule
+
+// Delay cells modeled as buffers
+module sg13g2_dlygate4sd1_1 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_dlygate4sd2_1 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
+module sg13g2_dlygate4sd3_1 (output electrical X, input electrical A);
+    sg13g2_buf_base buf_i(.X(X), .A(A));
+endmodule
 

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
@@ -17,15 +17,37 @@
 // Analog behavior parameters are declared per cell to mirror digital functionality
 
 // Basic combinational helpers
-module sg13g2_buf_base #(parameter real vh = 1.2, parameter real vl = 0, parameter real vth = (vh + vl)/2, parameter real td = 0 from [0:inf), parameter real tt = 0 from [0:inf)) (output electrical X, input electrical A);
+module sg13g2_buf_base (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A) - vth)) V(X) <+ transition((V(A) > vth) ? vh : vl, td, tt);
+    @(cross(V(A) - vth));
+
+    V(X) <+ transition((V(A) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_inv_base #(parameter real vh = 1.2, parameter real vl = 0, parameter real vth = (vh + vl)/2, parameter real td = 0 from [0:inf), parameter real tt = 0 from [0:inf)) (output electrical Y, input electrical A);
+module sg13g2_inv_base (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
+    parameter real vh = 1.2; /* high level */
+    parameter real vl = 0;   /* low level */
+    parameter real vth = (vh + vl)/2;
+    parameter real td = 0 from [0:inf);
+    parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A) - vth)) V(Y) <+ transition(!(V(A) > vth) ? vh : vl, td, tt);
+    @(cross(V(A) - vth));
+
+    V(Y) <+ transition(!(V(A) > vth) ? vh : vl, td, tt);
 end
 endmodule
 

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
@@ -52,152 +52,214 @@ end
 endmodule
 
 // Combinational cells
-module sg13g2_a21o_1 (output electrical X, input electrical A1, A2, B1);
+module sg13g2_a21o_1 (X, A1, A2, B1);
+    output X;
+    electrical X;
+    input A1, A2, B1;
+    electrical A1, A2, B1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
-        V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth));
+
+    V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_a21o_2 (output electrical X, input electrical A1, A2, B1);
+module sg13g2_a21o_2 (X, A1, A2, B1);
+    output X;
+    electrical X;
+    input A1, A2, B1;
+    electrical A1, A2, B1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
-        V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth));
+
+    V(X) <+ transition(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_a21oi_1 (output electrical Y, input electrical A1, A2, B1);
+module sg13g2_a21oi_1 (Y, A1, A2, B1);
+    output Y;
+    electrical Y;
+    input A1, A2, B1;
+    electrical A1, A2, B1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
-        V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth));
+
+    V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_a21oi_2 (output electrical Y, input electrical A1, A2, B1);
+module sg13g2_a21oi_2 (Y, A1, A2, B1);
+    output Y;
+    electrical Y;
+    input A1, A2, B1;
+    electrical A1, A2, B1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
-        V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth));
+
+    V(Y) <+ transition(!(((V(A1) > vth) && (V(A2) > vth)) || (V(B1) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_a221oi_1 (output electrical Y, input electrical A1, A2, B1, B2, C1);
+module sg13g2_a221oi_1 (Y, A1, A2, B1, B2, C1);
+    output Y;
+    electrical Y;
+    input A1, A2, B1, B2, C1;
+    electrical A1, A2, B1, B2, C1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth) or cross(V(C1)-vth))
-        V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth)) || (V(C1) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth) or cross(V(C1)-vth));
+
+    V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth)) || (V(C1) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_a22oi_1 (output electrical Y, input electrical A1, A2, B1, B2);
+module sg13g2_a22oi_1 (Y, A1, A2, B1, B2);
+    output Y;
+    electrical Y;
+    input A1, A2, B1, B2;
+    electrical A1, A2, B1, B2;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth))
-        V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth))) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth) or cross(V(B2)-vth));
+
+    V(Y) <+ transition(!(((V(A1) > vth)&&(V(A2) > vth)) || ((V(B1) > vth)&&(V(B2) > vth))) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and2_1 (output electrical X, input electrical A, B);
+module sg13g2_and2_1 (X, A, B);
+    output X;
+    electrical X;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and2_2 (output electrical X, input electrical A, B);
+module sg13g2_and2_2 (X, A, B);
+    output X;
+    electrical X;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and3_1 (output electrical X, input electrical A, B, C);
+module sg13g2_and3_1 (X, A, B, C);
+    output X;
+    electrical X;
+    input A, B, C;
+    electrical A, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and3_2 (output electrical X, input electrical A, B, C);
+module sg13g2_and3_2 (X, A, B, C);
+    output X;
+    electrical X;
+    input A, B, C;
+    electrical A, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and4_1 (output electrical X, input electrical A, B, C, D);
+module sg13g2_and4_1 (X, A, B, C, D);
+    output X;
+    electrical X;
+    input A, B, C, D;
+    electrical A, B, C, D;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_and4_2 (output electrical X, input electrical A, B, C, D);
+module sg13g2_and4_2 (X, A, B, C, D);
+    output X;
+    electrical X;
+    input A, B, C, D;
+    electrical A, B, C, D;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
-        V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(X) <+ transition((V(A) > vth) && (V(B) > vth) && (V(C) > vth) && (V(D) > vth) ? vh : vl, td, tt);
 end
 endmodule
 
 // Antenna/filler/decap cells do not drive signals
-module sg13g2_antennanp (input electrical A);
+module sg13g2_antennanp (A);
+    input A;
+    electrical A;
 endmodule
 module sg13g2_fill_1(); endmodule
 module sg13g2_fill_2(); endmodule
@@ -207,71 +269,126 @@ module sg13g2_decap_4(); endmodule
 module sg13g2_decap_8(); endmodule
 
 // Buffers and inverters
-module sg13g2_buf_1 (output electrical X, input electrical A);
+module sg13g2_buf_1 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_buf_2 (output electrical X, input electrical A);
+module sg13g2_buf_2 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_buf_4 (output electrical X, input electrical A);
+module sg13g2_buf_4 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_buf_8 (output electrical X, input electrical A);
+module sg13g2_buf_8 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_buf_16 (output electrical X, input electrical A);
+module sg13g2_buf_16 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
 
-module sg13g2_inv_1 (output electrical Y, input electrical A);
+module sg13g2_inv_1 (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
     sg13g2_inv_base inv_i(.Y(Y), .A(A));
 endmodule
-module sg13g2_inv_2 (output electrical Y, input electrical A);
+module sg13g2_inv_2 (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
     sg13g2_inv_base inv_i(.Y(Y), .A(A));
 endmodule
-module sg13g2_inv_4 (output electrical Y, input electrical A);
+module sg13g2_inv_4 (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
     sg13g2_inv_base inv_i(.Y(Y), .A(A));
 endmodule
-module sg13g2_inv_8 (output electrical Y, input electrical A);
+module sg13g2_inv_8 (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
     sg13g2_inv_base inv_i(.Y(Y), .A(A));
 endmodule
-module sg13g2_inv_16 (output electrical Y, input electrical A);
+module sg13g2_inv_16 (Y, A);
+    output Y;
+    electrical Y;
+    input A;
+    electrical A;
     sg13g2_inv_base inv_i(.Y(Y), .A(A));
 endmodule
 
 // Multiplexers
-module sg13g2_mux2_1 (output electrical X, input electrical A0, A1, S);
+module sg13g2_mux2_1 (X, A0, A1, S);
+    output X;
+    electrical X;
+    input A0, A1, S;
+    electrical A0, A1, S;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth))
-        V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth));
+
+    V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
 end
 endmodule
 
-module sg13g2_mux2_2 (output electrical X, input electrical A0, A1, S);
+module sg13g2_mux2_2 (X, A0, A1, S);
+    output X;
+    electrical X;
+    input A0, A1, S;
+    electrical A0, A1, S;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth))
-        V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(S)-vth));
+
+    V(X) <+ transition((V(S) > vth) ? ((V(A1) > vth)?vh:vl) : ((V(A0) > vth)?vh:vl), td, tt);
 end
 endmodule
 
-module sg13g2_mux4_1 (output electrical X, input electrical A0, A1, A2, A3, S0, S1);
+module sg13g2_mux4_1 (X, A0, A1, A2, A3, S0, S1);
+    output X;
+    electrical X;
+    input A0, A1, A2, A3, S0, S1;
+    electrical A0, A1, A2, A3, S0, S1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(A3)-vth) or cross(V(S0)-vth) or cross(V(S1)-vth)) begin
+    @(cross(V(A0)-vth) or cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(A3)-vth) or cross(V(S0)-vth) or cross(V(S1)-vth)) begin;
+
         integer sel0, sel1;
         sel0 = (V(S0) > vth);
         sel1 = (V(S1) > vth);
@@ -288,195 +405,275 @@ end
 endmodule
 
 // NAND / NOR variations
-module sg13g2_nand2_1 (output electrical Y, input electrical A, B);
+module sg13g2_nand2_1 (Y, A, B);
+    output Y;
+    electrical Y;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand2_2 (output electrical Y, input electrical A, B);
+module sg13g2_nand2_2 (Y, A, B);
+    output Y;
+    electrical Y;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) && (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand2b_1 (output electrical Y, input electrical A_N, B);
+module sg13g2_nand2b_1 (Y, A_N, B);
+    output Y;
+    electrical Y;
+    input A_N, B;
+    electrical A_N, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A_N)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A_N)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand2b_2 (output electrical Y, input electrical A_N, B);
+module sg13g2_nand2b_2 (Y, A_N, B);
+    output Y;
+    electrical Y;
+    input A_N, B;
+    electrical A_N, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A_N)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A_N)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((!(V(A_N) > vth)) && (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand3_1 (output electrical Y, input electrical A, B, C);
+module sg13g2_nand3_1 (Y, A, B, C);
+    output Y;
+    electrical Y;
+    input A, B, C;
+    electrical A, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand3b_1 (output electrical Y, input electrical A_N, B, C);
+module sg13g2_nand3b_1 (Y, A_N, B, C);
+    output Y;
+    electrical Y;
+    input A_N, B, C;
+    electrical A_N, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A_N)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(Y) <+ transition(!((!(V(A_N) > vth))&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A_N)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(Y) <+ transition(!((!(V(A_N) > vth))&&(V(B) > vth)&&(V(C) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nand4_1 (output electrical Y, input electrical A, B, C, D);
+module sg13g2_nand4_1 (Y, A, B, C, D);
+    output Y;
+    electrical Y;
+    input A, B, C, D;
+    electrical A, B, C, D;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
-        V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)&&(V(D) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)&&(V(B) > vth)&&(V(C) > vth)&&(V(D) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor2_1 (output electrical Y, input electrical A, B);
+module sg13g2_nor2_1 (Y, A, B);
+    output Y;
+    electrical Y;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor2_2 (output electrical Y, input electrical A, B);
+module sg13g2_nor2_2 (Y, A, B);
+    output Y;
+    electrical Y;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor2b_1 (output electrical Y, input electrical A, B_N);
+module sg13g2_nor2b_1 (Y, A, B_N);
+    output Y;
+    electrical Y;
+    input A, B_N;
+    electrical A, B_N;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B_N)-vth))
-        V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B_N)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor2b_2 (output electrical Y, input electrical A, B_N);
+module sg13g2_nor2b_2 (Y, A, B_N);
+    output Y;
+    electrical Y;
+    input A, B_N;
+    electrical A, B_N;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B_N)-vth))
-        V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B_N)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth) || !(V(B_N) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor3_1 (output electrical Y, input electrical A, B, C);
+module sg13g2_nor3_1 (Y, A, B, C);
+    output Y;
+    electrical Y;
+    input A, B, C;
+    electrical A, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor3_2 (output electrical Y, input electrical A, B, C);
+module sg13g2_nor3_2 (Y, A, B, C);
+    output Y;
+    electrical Y;
+    input A, B, C;
+    electrical A, B, C;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth))
-        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor4_1 (output electrical Y, input electrical A, B, C, D);
+module sg13g2_nor4_1 (Y, A, B, C, D);
+    output Y;
+    electrical Y;
+    input A, B, C, D;
+    electrical A, B, C, D;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
-        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_nor4_2 (output electrical Y, input electrical A, B, C, D);
+module sg13g2_nor4_2 (Y, A, B, C, D);
+    output Y;
+    electrical Y;
+    input A, B, C, D;
+    electrical A, B, C, D;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth))
-        V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+
+    V(Y) <+ transition(!((V(A) > vth)||(V(B) > vth)||(V(C) > vth)||(V(D) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_o21ai_1 (output electrical Y, input electrical A1, A2, B1);
+module sg13g2_o21ai_1 (Y, A1, A2, B1);
+    output Y;
+    electrical Y;
+    input A1, A2, B1;
+    electrical A1, A2, B1;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth))
-        V(Y) <+ transition(!(((V(A1) > vth)||(V(A2) > vth)) && (V(B1) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A1)-vth) or cross(V(A2)-vth) or cross(V(B1)-vth));
+
+    V(Y) <+ transition(!(((V(A1) > vth)||(V(A2) > vth)) && (V(B1) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
@@ -583,32 +780,46 @@ end
 endmodule
 
 // Exclusive gates
-module sg13g2_xor2_1 (output electrical X, input electrical A, B);
+module sg13g2_xor2_1 (X, A, B);
+    output X;
+    electrical X;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(X) <+ transition(((V(A) > vth) ^ (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(X) <+ transition(((V(A) > vth) ^ (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_xnor2_1 (output electrical Y, input electrical A, B);
+module sg13g2_xnor2_1 (Y, A, B);
+    output Y;
+    electrical Y;
+    input A, B;
+    electrical A, B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth))
-        V(Y) <+ transition(((V(A) > vth) ~^ (V(B) > vth)) ? vh : vl, td, tt);
+    @(cross(V(A)-vth) or cross(V(B)-vth));
+
+    V(Y) <+ transition(((V(A) > vth) ~^ (V(B) > vth)) ? vh : vl, td, tt);
 end
 endmodule
 
 // Tri-state and enable inverters
-module sg13g2_ebufn_2 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_ebufn_2 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -616,14 +827,19 @@ module sg13g2_ebufn_2 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = (V(A) > vth);
     end
     V(Z) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
-module sg13g2_ebufn_4 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_ebufn_4 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -631,14 +847,19 @@ module sg13g2_ebufn_4 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = (V(A) > vth);
     end
     V(Z) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
-module sg13g2_ebufn_8 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_ebufn_8 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -646,7 +867,8 @@ module sg13g2_ebufn_8 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = (V(A) > vth);
     end
@@ -654,7 +876,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_einvn_2 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_einvn_2 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -662,14 +888,19 @@ module sg13g2_einvn_2 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = !(V(A) > vth);
     end
     V(Z) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
-module sg13g2_einvn_4 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_einvn_4 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -677,14 +908,19 @@ module sg13g2_einvn_4 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = !(V(A) > vth);
     end
     V(Z) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
-module sg13g2_einvn_8 (inout electrical Z, input electrical A, TE_B);
+module sg13g2_einvn_8 (Z, A, TE_B);
+    inout Z;
+    electrical Z;
+    input A, TE_B;
+    electrical A, TE_B;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -692,7 +928,8 @@ module sg13g2_einvn_8 (inout electrical Z, input electrical A, TE_B);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin
+    @(cross(V(A)-vth) or cross(V(TE_B)-vth)) begin;
+
         if (!(V(TE_B) > vth))
             state = !(V(A) > vth);
     end
@@ -701,7 +938,9 @@ end
 endmodule
 
 // Tie cells
-module sg13g2_tiehi (output electrical L_HI);
+module sg13g2_tiehi (L_HI);
+    output L_HI;
+    electrical L_HI;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -712,7 +951,9 @@ analog begin
 end
 endmodule
 
-module sg13g2_tielo (output electrical L_LO);
+module sg13g2_tielo (L_LO);
+    output L_LO;
+    electrical L_LO;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -724,7 +965,11 @@ end
 endmodule
 
 // Clock gating helpers
-module sg13g2_lgcp_1 (output electrical GCLK, input electrical GATE, CLK);
+module sg13g2_lgcp_1 (GCLK, GATE, CLK);
+    output GCLK;
+    electrical GCLK;
+    input GATE, CLK;
+    electrical GATE, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -732,14 +977,19 @@ module sg13g2_lgcp_1 (output electrical GCLK, input electrical GATE, CLK);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(GATE)-vth) or cross(V(CLK)-vth)) begin
+    @(cross(V(GATE)-vth) or cross(V(CLK)-vth)) begin;
+
         state = (V(GATE) > vth) && (V(CLK) > vth);
     end
     V(GCLK) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
 
-module sg13g2_slgcp_1 (output electrical GCLK, input electrical GATE, SCE, CLK);
+module sg13g2_slgcp_1 (GCLK, GATE, SCE, CLK);
+    output GCLK;
+    electrical GCLK;
+    input GATE, SCE, CLK;
+    electrical GATE, SCE, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -747,7 +997,8 @@ module sg13g2_slgcp_1 (output electrical GCLK, input electrical GATE, SCE, CLK);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(GATE)-vth) or cross(V(SCE)-vth) or cross(V(CLK)-vth)) begin
+    @(cross(V(GATE)-vth) or cross(V(SCE)-vth) or cross(V(CLK)-vth)) begin;
+
         state = (((V(GATE) > vth) && !(V(SCE) > vth)) || (V(SCE) > vth)) && (V(CLK) > vth);
     end
     V(GCLK) <+ transition(state ? vh : vl, td, tt);
@@ -755,7 +1006,11 @@ end
 endmodule
 
 // Latches
-module sg13g2_dlhq_1 (output electrical Q, input electrical D, GATE);
+module sg13g2_dlhq_1 (Q, D, GATE);
+    output Q;
+    electrical Q;
+    input D, GATE;
+    electrical D, GATE;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -763,7 +1018,8 @@ module sg13g2_dlhq_1 (output electrical Q, input electrical D, GATE);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(GATE)-vth)) begin
+    @(cross(V(D)-vth) or cross(V(GATE)-vth)) begin;
+
         if ((V(GATE) > vth))
             state = (V(D) > vth);
     end
@@ -771,7 +1027,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dlhr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GATE);
+module sg13g2_dlhr_1 (Q, Q_N, D, RESET_B, GATE);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, RESET_B, GATE;
+    electrical D, RESET_B, GATE;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -779,7 +1039,8 @@ module sg13g2_dlhr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GAT
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if ((V(GATE) > vth))
@@ -790,7 +1051,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dlhrq_1 (output electrical Q, input electrical D, RESET_B, GATE);
+module sg13g2_dlhrq_1 (Q, D, RESET_B, GATE);
+    output Q;
+    electrical Q;
+    input D, RESET_B, GATE;
+    electrical D, RESET_B, GATE;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -798,7 +1063,8 @@ module sg13g2_dlhrq_1 (output electrical Q, input electrical D, RESET_B, GATE);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if ((V(GATE) > vth))
@@ -808,7 +1074,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dllr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GATE_N);
+module sg13g2_dllr_1 (Q, Q_N, D, RESET_B, GATE_N);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, RESET_B, GATE_N;
+    electrical D, RESET_B, GATE_N;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -816,7 +1086,8 @@ module sg13g2_dllr_1 (output electrical Q, Q_N, input electrical D, RESET_B, GAT
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (!(V(GATE_N) > vth))
@@ -827,7 +1098,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dllrq_1 (output electrical Q, input electrical D, RESET_B, GATE_N);
+module sg13g2_dllrq_1 (Q, D, RESET_B, GATE_N);
+    output Q;
+    electrical Q;
+    input D, RESET_B, GATE_N;
+    electrical D, RESET_B, GATE_N;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -835,7 +1110,8 @@ module sg13g2_dllrq_1 (output electrical Q, input electrical D, RESET_B, GATE_N)
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin
+    @(cross(V(D)-vth) or cross(V(RESET_B)-vth) or cross(V(GATE_N)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (!(V(GATE_N) > vth))
@@ -846,7 +1122,11 @@ end
 endmodule
 
 // D flip-flops
-module sg13g2_dfrbp_1 (output electrical Q, Q_N, input electrical D, RESET_B, CLK);
+module sg13g2_dfrbp_1 (Q, Q_N, D, RESET_B, CLK);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, RESET_B, CLK;
+    electrical D, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -854,7 +1134,8 @@ module sg13g2_dfrbp_1 (output electrical Q, Q_N, input electrical D, RESET_B, CL
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -865,7 +1146,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dfrbp_2 (output electrical Q, Q_N, input electrical D, RESET_B, CLK);
+module sg13g2_dfrbp_2 (Q, Q_N, D, RESET_B, CLK);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, RESET_B, CLK;
+    electrical D, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -873,7 +1158,8 @@ module sg13g2_dfrbp_2 (output electrical Q, Q_N, input electrical D, RESET_B, CL
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -884,7 +1170,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dfrbpq_1 (output electrical Q, input electrical D, RESET_B, CLK);
+module sg13g2_dfrbpq_1 (Q, D, RESET_B, CLK);
+    output Q;
+    electrical Q;
+    input D, RESET_B, CLK;
+    electrical D, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -892,7 +1182,8 @@ module sg13g2_dfrbpq_1 (output electrical Q, input electrical D, RESET_B, CLK);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -902,7 +1193,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_dfrbpq_2 (output electrical Q, input electrical D, RESET_B, CLK);
+module sg13g2_dfrbpq_2 (Q, D, RESET_B, CLK);
+    output Q;
+    electrical Q;
+    input D, RESET_B, CLK;
+    electrical D, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -910,7 +1205,8 @@ module sg13g2_dfrbpq_2 (output electrical Q, input electrical D, RESET_B, CLK);
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin
+    @(cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1) or cross(V(D)-vth)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -921,7 +1217,11 @@ end
 endmodule
 
 // Scan DFF with reset and optional set
-module sg13g2_sdfbbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, SET_B, CLK);
+module sg13g2_sdfbbp_1 (Q, Q_N, D, SCD, SCE, RESET_B, SET_B, CLK);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, SCD, SCE, RESET_B, SET_B, CLK;
+    electrical D, SCD, SCE, RESET_B, SET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -929,7 +1229,8 @@ module sg13g2_sdfbbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, 
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(SET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(SET_B)-vth) or cross(V(CLK)-vth, +1)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (!(V(SET_B) > vth))
@@ -942,7 +1243,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_sdfrbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, CLK);
+module sg13g2_sdfrbp_1 (Q, Q_N, D, SCD, SCE, RESET_B, CLK);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, SCD, SCE, RESET_B, CLK;
+    electrical D, SCD, SCE, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -950,7 +1255,8 @@ module sg13g2_sdfrbp_1 (output electrical Q, Q_N, input electrical D, SCD, SCE, 
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -961,7 +1267,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_sdfrbp_2 (output electrical Q, Q_N, input electrical D, SCD, SCE, RESET_B, CLK);
+module sg13g2_sdfrbp_2 (Q, Q_N, D, SCD, SCE, RESET_B, CLK);
+    output Q, Q_N;
+    electrical Q, Q_N;
+    input D, SCD, SCE, RESET_B, CLK;
+    electrical D, SCD, SCE, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -969,7 +1279,8 @@ module sg13g2_sdfrbp_2 (output electrical Q, Q_N, input electrical D, SCD, SCE, 
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -980,7 +1291,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_sdfrbpq_1 (output electrical Q, input electrical D, SCD, SCE, RESET_B, CLK);
+module sg13g2_sdfrbpq_1 (Q, D, SCD, SCE, RESET_B, CLK);
+    output Q;
+    electrical Q;
+    input D, SCD, SCE, RESET_B, CLK;
+    electrical D, SCD, SCE, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -988,7 +1303,8 @@ module sg13g2_sdfrbpq_1 (output electrical Q, input electrical D, SCD, SCE, RESE
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -998,7 +1314,11 @@ analog begin
 end
 endmodule
 
-module sg13g2_sdfrbpq_2 (output electrical Q, input electrical D, SCD, SCE, RESET_B, CLK);
+module sg13g2_sdfrbpq_2 (Q, D, SCD, SCE, RESET_B, CLK);
+    output Q;
+    electrical Q;
+    input D, SCD, SCE, RESET_B, CLK;
+    electrical D, SCD, SCE, RESET_B, CLK;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -1006,7 +1326,8 @@ module sg13g2_sdfrbpq_2 (output electrical Q, input electrical D, SCD, SCE, RESE
     parameter real tt = 0 from [0:inf);
     real state;
 analog begin
-    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin
+    @(cross(V(D)-vth) or cross(V(SCD)-vth) or cross(V(SCE)-vth) or cross(V(RESET_B)-vth) or cross(V(CLK)-vth, +1)) begin;
+
         if (!(V(RESET_B) > vth))
             state = 0;
         else if (cross(V(CLK)-vth, +1))
@@ -1017,7 +1338,9 @@ end
 endmodule
 
 // Bus hold cell
-module sg13g2_sighold (inout electrical SH);
+module sg13g2_sighold (SH);
+    inout SH;
+    electrical SH;
     parameter real vh = 1.2; /* high level */
     parameter real vl = 0;   /* low level */
     parameter real vth = (vh + vl)/2;
@@ -1026,18 +1349,31 @@ module sg13g2_sighold (inout electrical SH);
     real state;
 analog begin
     @(cross(V(SH)-vth)) state = (V(SH) > vth);
+
     V(SH) <+ transition(state ? vh : vl, td, tt);
 end
 endmodule
 
 // Delay cells modeled as buffers
-module sg13g2_dlygate4sd1_1 (output electrical X, input electrical A);
+module sg13g2_dlygate4sd1_1 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_dlygate4sd2_1 (output electrical X, input electrical A);
+module sg13g2_dlygate4sd2_1 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
-module sg13g2_dlygate4sd3_1 (output electrical X, input electrical A);
+module sg13g2_dlygate4sd3_1 (X, A);
+    output X;
+    electrical X;
+    input A;
+    electrical A;
     sg13g2_buf_base buf_i(.X(X), .A(A));
 endmodule
 

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.vams
@@ -469,7 +469,7 @@ module sg13g2_or2_1 (X, A, B);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
 end
@@ -486,7 +486,7 @@ module sg13g2_or2_2 (X, A, B);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth)) ? vh : vl, td, tt);
 end
@@ -503,7 +503,7 @@ module sg13g2_or3_1 (X, A, B, C);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth) or cross(V(C) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth)) ? vh : vl, td, tt);
 end
@@ -520,7 +520,7 @@ module sg13g2_or3_2 (X, A, B, C);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth) or cross(V(C) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth)) ? vh : vl, td, tt);
 end
@@ -537,7 +537,7 @@ module sg13g2_or4_1 (X, A, B, C, D);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth) or cross(V(C) - vth) or cross(V(D) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth) || (V(D) > vth)) ? vh : vl, td, tt);
 end
@@ -554,7 +554,7 @@ module sg13g2_or4_2 (X, A, B, C, D);
     parameter real td = 0 from [0:inf);
     parameter real tt = 0 from [0:inf);
 analog begin
-    @(cross(V(A)-vth) or cross(V(B)-vth) or cross(V(C)-vth) or cross(V(D)-vth));
+    @(cross(V(A) - vth) or cross(V(B) - vth) or cross(V(C) - vth) or cross(V(D) - vth));
 
     V(X) <+ transition(((V(A) > vth) || (V(B) > vth) || (V(C) > vth) || (V(D) > vth)) ? vh : vl, td, tt);
 end


### PR DESCRIPTION
## Summary
- reformat OR2/OR3/OR4 Verilog-AMS modules to match the working per-cell declaration style
- use standalone cross events with explicit transition assignments for OR gate outputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694d5e511ad8832a88650a94e38e73b1)