### PR TITLE
Add `rhigh`/`rppd` resistor parameters to gnucap models

### DIFF
--- a/ihp-sg13g2/libs.tech/gnucap/models/cornerRES.vams
+++ b/ihp-sg13g2/libs.tech/gnucap/models/cornerRES.vams
@@ -1,21 +1,28 @@
 
 `ifdef res_typ
+`define rsh_rhigh 1360
+`define rsh_rppd 260.0
 `define rsh_rsil 7.0
 `include "resistors_paramsets.vams"
 `endif
 
 `ifdef res_bcs
+`define rsh_rhigh 1020
+`define rsh_rppd 234.0
 `define rsh_rsil 6.02
 `include "resistors_paramsets.vams"
 `endif
 
 `ifdef res_wcs
+`define rsh_rhigh 1700
+`define rsh_rppd 286.0
 `define rsh_rsil 7.98
 `include "resistors_paramsets.vams"
 `endif
 
 `ifdef res_stat
+`define rsh_rhigh 1360
+`define rsh_rppd 260.0
 `define rsh_rsil 7.0
 `include "resistors_paramsets_stat.vams"
 `endif
-

--- a/ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets.vams
+++ b/ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets.vams
@@ -76,6 +76,297 @@ paramset rsil r3_cmc
 endparamset
 
 
+paramset rhigh r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real l = 0.96e-6 from [0.5e-6:10e-6);
+  parameter real b = 0;
+  parameter integer mm_ok = 0 from [0:0];
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w - 0.04e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 80e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rshspec = 1360;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rhigh = `rsh_rhigh;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 2.1e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9086;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = -0.04;
+    .ecrit = 1000;
+    .afn = 1.935;
+    .tc1 = -2300e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rhigh;
+    .l = leff;
+    .kfn = 5.205e-10;
+    .cthp = 0;
+    .smm_rsh = 5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .tc2rc = 2.1e-6;
+    .dp = 1000;
+    .tc1rc = -2300e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+      
+endparamset
+
+
+paramset rhigh r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.1e-6:10e-6);
+  parameter real l = 0.96e-6 from [0.5e-6:10e-6);
+  parameter integer mm_ok = 1  from [1:1];
+  parameter real b = 0;
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w - 0.04e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 80e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rshspec = 1360;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rhigh = $rdist_normal(_rdist_seed, `rsh_rhigh, `rsh_rhigh * 0.05);
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 2.1e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9086;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = -0.04;
+    .ecrit = 1000;
+    .afn = 1.935;
+    .tc1 = -2300e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rhigh;
+    .l = leff;
+    .kfn = 5.205e-10;
+    .cthp = 0;
+    .smm_rsh = 5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .tc2rc = 2.1e-6;
+    .dp = 1000;
+    .tc1rc = -2300e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+      
+endparamset
+
+
+paramset rppd r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real l = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real b = 0;
+  parameter integer mm_ok = 0 from [0:0];
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w + 0.006e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 35e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rppd = `rsh_rppd;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 0.4e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9963;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = 0.006;
+    .ecrit = 1000;
+    .afn = 1.886;
+    .tc1 = 170e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rppd;
+    .l = leff;
+    .kfn = 4.601e-11;
+    .cthp = 0;
+    .smm_rsh = 1.5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .dp = 1000;
+    .tc1rc = -950e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+      
+endparamset
+
+
+paramset rppd r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.1e-6:10e-6);
+  parameter real l = 0.5e-6 from [0.5e-6:10e-6);
+  parameter integer mm_ok = 1  from [1:1];
+  parameter real b = 0;
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w + 0.006e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 35e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rppd = $rdist_normal(_rdist_seed, `rsh_rppd, `rsh_rppd * 0.015);
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 0.4e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9963;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = 0.006;
+    .ecrit = 1000;
+    .afn = 1.886;
+    .tc1 = 170e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rppd;
+    .l = leff;
+    .kfn = 4.601e-11;
+    .cthp = 0;
+    .smm_rsh = 1.5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .dp = 1000;
+    .tc1rc = -950e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+      
+endparamset
+
 paramset rsil r3_cmc
   
   parameter integer _rdist_seed = 0;

--- a/ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets_stat.vams
+++ b/ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets_stat.vams
@@ -75,6 +75,294 @@ paramset rsil r3_cmc
 
 endparamset 
 
+paramset rhigh r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real l = 0.96e-6 from [0.5e-6:10e-6);
+  parameter real b = 0;
+  parameter integer mm_ok = 0 from [0:0];
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w - 0.04e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 80e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rshspec = 1360;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rhigh = global_res_typ.rsh_rhigh_eff;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 2.1e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9086;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = -0.04;
+    .ecrit = 1000;
+    .afn = 1.935;
+    .tc1 = -2300e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rhigh;
+    .l = leff;
+    .kfn = 5.205e-10;
+    .cthp = 0;
+    .smm_rsh = 5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .tc2rc = 2.1e-6;
+    .dp = 1000;
+    .tc1rc = -2300e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+
+endparamset 
+
+paramset rhigh r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.1e-6:10e-6);
+  parameter real l = 0.96e-6 from [0.5e-6:10e-6);
+  parameter integer mm_ok = 1  from [1:1];
+  parameter real b = 0;
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w - 0.04e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 80e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rshspec = 1360;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rhigh = $rdist_normal(_rdist_seed, 0.0, 68.0) + global_res_typ.rsh_rhigh_eff;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 2.1e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9086;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = -0.04;
+    .ecrit = 1000;
+    .afn = 1.935;
+    .tc1 = -2300e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rhigh;
+    .l = leff;
+    .kfn = 5.205e-10;
+    .cthp = 0;
+    .smm_rsh = 5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .tc2rc = 2.1e-6;
+    .dp = 1000;
+    .tc1rc = -2300e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+     
+endparamset 
+
+paramset rppd r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real l = 0.5e-6 from [0.5e-6:10e-6);
+  parameter real b = 0;
+  parameter integer mm_ok = 0 from [0:0];
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w + 0.006e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 35e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rppd = global_res_typ.rsh_rppd_eff;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 0.4e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9963;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = 0.006;
+    .ecrit = 1000;
+    .afn = 1.886;
+    .tc1 = 170e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rppd;
+    .l = leff;
+    .kfn = 4.601e-11;
+    .cthp = 0;
+    .smm_rsh = 1.5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .dp = 1000;
+    .tc1rc = -950e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+
+endparamset 
+
+paramset rppd r3_cmc
+  
+  parameter integer _rdist_seed = 0;
+  parameter real w = 0.5e-6 from [0.1e-6:10e-6);
+  parameter real l = 0.5e-6 from [0.5e-6:10e-6);
+  parameter integer mm_ok = 1  from [1:1];
+  parameter real b = 0;
+  parameter real m = 1;
+  parameter real trise = 0;
+  parameter real sw_et = 0;
+  parameter real postsim = 0;
+  parameter real kappa = 1.85;
+  parameter real ps = 0.18e-6;
+  parameter real weff = w + 0.006e-6;
+  parameter real leff = (b + 1) * l + (2 / kappa * weff + ps) * b;
+  parameter real lhead = 0.86e-6;
+  parameter real rzspec = 35e-6;
+  parameter real cax = 90e-18;
+  parameter real cpx = 25e-18;
+  parameter real ax = 175e-18 * (1 - 1 / (1.5 * leff * 1e6 + 1)) / cax;
+  parameter real px = 115e-18 / cpx;
+  parameter real a0 = 0.5 * (leff + lhead) * w - (postsim > 0) * w * ax * 1e-6;
+  parameter real a = (a0 > 0) * a0;
+  parameter real p0 = leff + lhead + w - (postsim > 0) * px * 1e-6;
+  parameter real p = (p0 > 0) * p0;
+  parameter real rqrc = 4.5e-6;
+  parameter real rz = rzspec / w - (postsim > 0) * rqrc / w;
+  parameter real rsh_rppd = $rdist_normal(_rdist_seed, 0.0, 3.9) + global_res_typ.rsh_rppd_eff;
+  //parameter real rsh_rppd = 260.0;
+
+    .c1 = 1;
+    .a2 = a;
+    .tc2 = 0.4e-6;
+    .a1 = a;
+    .trise = trise;
+    .dfinf = 1e-4;
+    .gthp = 2e-6;
+    .cp = cpx;
+    .gth0 = 1e-12;
+    .cth0 = 0;
+    .nsmm_rsh = 1;
+    .bfn = 0.9963;
+    .gtha = 6e-6;
+    .sw_mman = 1;
+    .ca = cax;
+    .gthc = 1e-12;
+    .nsmm_w = 1;
+    .ctha = 594e-15;
+    .sw_et = sw_et;
+    .rc = rz;
+    .xw = 0.006;
+    .ecrit = 1000;
+    .afn = 1.886;
+    .tc1 = 170e-6;
+    .w = weff;
+    .c2 = 1;
+    .rsh =  rsh_rppd;
+    .l = leff;
+    .kfn = 4.601e-11;
+    .cthp = 0;
+    .smm_rsh = 1.5;
+    .cthc = 0;
+    .nsmm_l = 1;
+    .smm_w = 0.01;
+    .dp = 1000;
+    .tc1rc = -950e-6;
+    .p2 = p;
+    .p1 = p;
+    .smm_l = 0.01;
+     
+endparamset 
 paramset rsil r3_cmc
   
   parameter integer _rdist_seed = 0;

--- a/ihp-sg13g2/libs.tech/gnucap/models/resistors_stat.vams
+++ b/ihp-sg13g2/libs.tech/gnucap/models/resistors_stat.vams
@@ -7,21 +7,33 @@ module res_typ_stat();
 
   // ---- nominal (per corner) ----
   parameter real rsh_rsil_nom = 7.0;     // ohm/sq (example)
+  parameter real rsh_rhigh_nom = 1360;   // ohm/sq (example)
+  parameter real rsh_rppd_nom = 260.0;   // ohm/sq (example)
 
   // ---- 1-sigma variations (example numbers) ----
   parameter real rsh_rsil_sigma_g = 0.0467; // ohm/sq global
+  parameter real rsh_rhigh_sigma_g = 0.0833; // ohm/sq global
+  parameter real rsh_rppd_sigma_g = 0.033; // ohm/sq global
   parameter real rsh_rsil_sigma_l = 0.20; // ohm/sq local
+  parameter real rsh_rhigh_sigma_l = 68.0; // ohm/sq local
+  parameter real rsh_rppd_sigma_l = 3.9; // ohm/sq local
 
   // ---- global (shared across instances) ----
   // parameter real drsh_g = $rdist_normal(SEED, 0.0, rsh_rsil_sigma_g, "global");
   parameter real drsh_g = $rdist_normal(SEED, 0.0, rsh_rsil_sigma_g);
+  parameter real drsh_rhigh_g = $rdist_normal(SEED, 0.0, rsh_rhigh_sigma_g);
+  parameter real drsh_rppd_g = $rdist_normal(SEED, 0.0, rsh_rppd_sigma_g);
 
   // ---- local (instance mismatch) ----
   // parameter real drsh_l = $rdist_normal(SEED, 0.0, rsh_rsil_sigma_l, "instance");
   parameter real drsh_l = $rdist_normal(SEED, 0.0, rsh_rsil_sigma_l);
+  parameter real drsh_rhigh_l = $rdist_normal(SEED, 0.0, rsh_rhigh_sigma_l);
+  parameter real drsh_rppd_l = $rdist_normal(SEED, 0.0, rsh_rppd_sigma_l);
 
   // ---- final effective params for this corner ----
   parameter real rsh_rsil_eff = rsh_rsil_nom + drsh_g + drsh_l;
+  parameter real rsh_rhigh_eff = rsh_rhigh_nom + drsh_rhigh_g + drsh_rhigh_l;
+  parameter real rsh_rppd_eff = rsh_rppd_nom + drsh_rppd_g + drsh_rppd_l;
 endmodule
 
 module res_typ();
@@ -32,15 +44,22 @@ module res_typ();
 
   // ---- nominal (per corner) ----
   parameter real rsh_rsil_nom = 7.0;     // ohm/sq (example)
+  parameter real rsh_rhigh_nom = 1360;   // ohm/sq (example)
+  parameter real rsh_rppd_nom = 260.0;   // ohm/sq (example)
 
   // ---- 1-sigma variations (example numbers) ----
   parameter real rsh_rsil_sigma_l = 0.20; // ohm/sq local
+  parameter real rsh_rhigh_sigma_l = 68.0; // ohm/sq local
+  parameter real rsh_rppd_sigma_l = 3.9; // ohm/sq local
 
   // ---- local (instance mismatch) ----
   parameter real drsh_l = xyz;
+  parameter real drsh_rhigh_l = xyz;
+  parameter real drsh_rppd_l = xyz;
 
   // ---- final effective params for this corner ----
   parameter real rsh_rsil_eff = rsh_rsil_nom  + drsh_l;
+  parameter real rsh_rhigh_eff = rsh_rhigh_nom + drsh_rhigh_l;
+  parameter real rsh_rppd_eff = rsh_rppd_nom + drsh_rppd_l;
 endmodule
-
 


### PR DESCRIPTION
### Motivation

- Bring gnucap resistor models in line with the ngspice resistor definitions by adding `rsh_rhigh` and `rsh_rppd` corner values and parameter pairs so the same corner values are available for gnucap flows.
- Support both deterministic and statistical/mismatch variants of the `rhigh` and `rppd` resistor models to enable corner and Monte‑Carlo usage in gnucap.

### Description

- Added corner macros in `ihp-sg13g2/libs.tech/gnucap/models/cornerRES.vams` for `rsh_rhigh` and `rsh_rppd` for `res_typ`, `res_bcs`, `res_wcs`, and `res_stat` to mirror values from the ngspice `cornerRES.lib` file.
- Extended `ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets.vams` with new `paramset` blocks for `rhigh` and `rppd` (both nominal and mismatch variants) that map `.rsh` to `rsh_rhigh`/`rsh_rppd` and use the same geometry and internal parameters as the existing `rsil` paramsets.
- Extended `ihp-sg13g2/libs.tech/gnucap/models/resistors_paramsets_stat.vams` to add statistical/stochastic `paramset` variants for `rhigh` and `rppd` which reference `global_res_typ` effective values and include `$rdist_normal` sampling where appropriate.
- Updated `ihp-sg13g2/libs.tech/gnucap/models/resistors_stat.vams` to declare nominal and sigma values for `rsh_rhigh` and `rsh_rppd`, add global/local deviation variables, and compute `rsh_rhigh_eff` and `rsh_rppd_eff` for statistical corner generation.
- Committed the changes to the repository (`git commit` completed) after verifying modified files with listing/line checks.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b6f912e54832a963cf42c264a1584)